### PR TITLE
Added OS as variable in build matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,12 +4,13 @@ on: [push, pull_request]
 
 jobs:
   main:
-    runs-on: ubuntu-latest
-
     strategy:
       fail-fast: true
       matrix:
-        python: ['3.8.5', '3.9']
+        os: [ubuntu-latest, macos-latest]
+        python: ['3.8.5', '3.8.6', '3.9']
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Project checkout


### PR DESCRIPTION
## Description

Adds Linux and MacOS as variables in the build matrix for the `main` Workflow in Github Actions CI

## Motivation and Context
I want this template to be ready to catch messed behaviours due to corrupted and/or incomplete tools in the base OS, eg missing compilers in MacOS Catalina (and further)

## Types of changes
> What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Implementation details
Build matrix is now patched with OS dimension and also with Python `3.8.6`
