### PR TITLE
Change Github Action to install and configure Python Poetry

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: ${{ matrix.python }}
 
       - name: Install Poetry
-        uses: dschep/install-poetry-action@v1.3
+        uses: snok/install-poetry@v1.1.1
 
       - name: Install dependencies
         run: make setup

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,9 @@ jobs:
 
       - name: Install Poetry
         uses: snok/install-poetry@v1.1.1
+        with:
+          virtualenvs-create: false
+          virtualenvs-in-project: false
 
       - name: Install dependencies
         run: make setup

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: '3.8.5'
 
       - name: Install Poetry
-        uses: dschep/install-poetry-action@v1.3
+        uses: snok/install-poetry@v1.1.1
 
       - name: Install dependencies
         run: make setup

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,9 @@ jobs:
 
       - name: Install Poetry
         uses: snok/install-poetry@v1.1.1
+        with:
+          virtualenvs-create: false
+          virtualenvs-in-project: false
 
       - name: Install dependencies
         run: make setup


### PR DESCRIPTION
## Description
Changes the Github Action that installs and configures Python Poetry to https://github.com/snok/install-poetry

## Motivation and Context
Since the [previously GHA](https://github.com/dschep/install-poetry-action
) used to install/configure Poetry was deprecated by the author and given that Github Runners started to break builds where pipelines eventually run  the `add-path` command, we need to migrate to a new Github Action for this.


## Types of changes

- [x] House cleaning (small change at project level)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Implementation details
N/A